### PR TITLE
feat: add 'ready' command to list tasks ready to start

### DIFF
--- a/.tsks/tasks.jsonl
+++ b/.tsks/tasks.jsonl
@@ -39,7 +39,7 @@
 {"id":"44","title":"Add tssk Task Management","status":"done","created_at":"2026-04-09T14:24:24.186223473Z","doc_hash":"f9bd092fae9ab448c4dd9c96c29bec66d74c1290a2867f1810a0e2b0538d45b3"}
 {"id":"45","title":"Move default config file location","status":"todo","created_at":"2026-04-09T14:24:31.170932152Z","doc_hash":"f5d4cc4297649eb790f45490cbf4b417af6d435ee9c748aa1cfa93c26e456f99"}
 {"id":"46","title":"Add 'removed' status and command","status":"todo","created_at":"2026-04-09T14:24:42.476278878Z","doc_hash":"79d190428f3ea9194ad49cf469d22b44709385604821d3f7acdc2a5b0ffd7e6d"}
-{"id":"47","title":"Add 'ready' command to show ready tasks","status":"todo","created_at":"2026-04-09T14:25:00.522555503Z","doc_hash":"2204e21beba0fca434468fd6fa6a47834cecde92c1b4dff03bf1093f51487f79"}
+{"id":"47","title":"Add 'ready' command to show ready tasks","status":"done","created_at":"2026-04-09T14:25:00.522555503Z","doc_hash":"2204e21beba0fca434468fd6fa6a47834cecde92c1b4dff03bf1093f51487f79"}
 {"id":"48","title":"Add command to tidy up docs directory","status":"todo","created_at":"2026-04-09T14:25:09.509594234Z","doc_hash":"af29758803d882af78a695547aaa46151e800e7f466a6b4ff67f7001629e2218"}
 {"id":"49","title":"Add tags to the JSONL file","status":"todo","created_at":"2026-04-09T14:25:25.948252129Z","doc_hash":"7684526c6c0f54849e61ddb74f3e9014d77c680da51d12c9680040435bdf6ed3"}
 {"id":"50","title":"Add optional duration estimate","status":"todo","created_at":"2026-04-09T14:25:40.895703813Z","doc_hash":"e8c70b2ea49ccabbfb7438c364df6a36fc1ee81aa1e81930517877181dbda1d4"}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ Flags:
 
 - `-s, --status` - Filter by status (`todo`, `in-progress`, `done`, `blocked`)
 
+### List ready tasks
+
+```bash
+tssk ready
+```
+
+Lists all tasks with status `todo` that do not depend on any task with status `todo` or `in-progress`. A task is considered "ready" when it has no blocking dependencies, meaning all its dependencies (if any) are either `done` or `blocked`.
+
+Flags:
+
+- `--json` - Output tasks as JSON
+
 ### Show a task
 
 ```bash

--- a/cmd/ready.go
+++ b/cmd/ready.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bmordue/tssk/internal/task"
+)
+
+var readyJSON bool
+
+var readyCmd = &cobra.Command{
+	Use:   "ready",
+	Short: "List tasks that are ready to start",
+	Long: `List all tasks with status 'todo' that do not depend on any task 
+with status 'todo' or 'in-progress'.
+
+A task is considered "ready" when it has no blocking dependencies, meaning
+all its dependencies (if any) are either 'done' or 'blocked'.
+
+Note: Tasks with 'blocked' dependencies are considered ready, as 'blocked'
+indicates an external blocker rather than active work in progress.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		st, err := openStore()
+		if err != nil {
+			return err
+		}
+
+		tasks, err := st.LoadAll()
+		if err != nil {
+			return err
+		}
+
+		// Build a map for quick task lookup.
+		taskByID := make(map[string]*task.Task, len(tasks))
+		for _, t := range tasks {
+			taskByID[t.ID] = t
+		}
+
+		// Collect ready tasks and track warnings.
+		var readyTasks []*task.Task
+		var warnings []string
+		for _, t := range tasks {
+			if t.Status != task.StatusTodo {
+				continue
+			}
+
+			// Check if any dependency has status 'todo' or 'in-progress'.
+			hasBlockingDep := false
+			for _, depID := range t.Dependencies {
+				dep, ok := taskByID[depID]
+				if !ok {
+					// Missing dependency - treat as blocking and warn.
+					hasBlockingDep = true
+					warnings = append(warnings, fmt.Sprintf("warning: task %s depends on non-existent task %s", t.ID, depID))
+					break
+				}
+				if dep.Status == task.StatusTodo || dep.Status == task.StatusInProgress {
+					hasBlockingDep = true
+					break
+				}
+			}
+
+			if !hasBlockingDep {
+				readyTasks = append(readyTasks, t)
+			}
+		}
+
+		// Emit warnings to stderr.
+		for _, w := range warnings {
+			fmt.Fprintln(cmd.ErrOrStderr(), w)
+		}
+
+		if readyJSON {
+			if readyTasks == nil {
+				readyTasks = []*task.Task{}
+			}
+			return printJSON(readyTasks)
+		}
+
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tSTATUS\tTITLE\tTAGS\tDEPS")
+		for _, t := range readyTasks {
+			tags := "-"
+			if len(t.Tags) > 0 {
+				tags = strings.Join(t.Tags, ", ")
+			}
+			deps := "-"
+			if len(t.Dependencies) > 0 {
+				deps = strings.Join(t.Dependencies, ", ")
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.ID, t.Status, t.Title, tags, deps)
+		}
+		_ = w.Flush()
+		return nil
+	},
+}
+
+func init() {
+	readyCmd.Flags().BoolVar(&readyJSON, "json", false, "Output tasks as JSON")
+}

--- a/cmd/ready.go
+++ b/cmd/ready.go
@@ -56,7 +56,7 @@ indicates an external blocker rather than active work in progress.`,
 					// Missing dependency - treat as blocking and warn.
 					hasBlockingDep = true
 					warnings = append(warnings, fmt.Sprintf("warning: task %s depends on non-existent task %s", t.ID, depID))
-					break
+					continue
 				}
 				if dep.Status == task.StatusTodo || dep.Status == task.StatusInProgress {
 					hasBlockingDep = true

--- a/cmd/ready_test.go
+++ b/cmd/ready_test.go
@@ -295,19 +295,24 @@ func TestReadyCommand_MissingDependency(t *testing.T) {
 	t.Setenv("TSSK_ROOT", dir)
 
 	cmd := readyCmd
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
 
 	err = cmd.RunE(cmd, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	output := buf.String()
+	output := outBuf.String()
 	// Should not contain the task (missing dep treated as blocking)
-	if bytes.Contains(buf.Bytes(), []byte("Task with missing dep")) {
+	if bytes.Contains(outBuf.Bytes(), []byte("Task with missing dep")) {
 		t.Errorf("did not expect 'Task with missing dep' in output (missing dep should block), got: %s", output)
+	}
+
+	if errBuf.Len() == 0 {
+		t.Errorf("expected warning output on stderr for missing dependency, got none")
 	}
 }
 

--- a/cmd/ready_test.go
+++ b/cmd/ready_test.go
@@ -1,0 +1,406 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/bmordue/tssk/internal/store"
+	"github.com/bmordue/tssk/internal/task"
+)
+
+func setupReadyTestStore(t *testing.T) (*store.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	s := store.New(dir)
+	return s, dir
+}
+
+func TestReadyCommand_NoTasks(t *testing.T) {
+	_, dir := setupReadyTestStore(t)
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	cmd := readyCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err := cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should output empty table with header
+	output := buf.String()
+	if output == "" {
+		t.Error("expected output, got empty string")
+	}
+}
+
+func TestReadyCommand_AllReady(t *testing.T) {
+	s, dir := setupReadyTestStore(t)
+
+	// Add tasks with no dependencies - all should be ready
+	_, err := s.Add("Task 1", "detail 1", nil, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	_, err = s.Add("Task 2", "detail 2", nil, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	cmd := readyCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	// Should contain both tasks
+	if !bytes.Contains(buf.Bytes(), []byte("Task 1")) {
+		t.Errorf("expected 'Task 1' in output, got: %s", output)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("Task 2")) {
+		t.Errorf("expected 'Task 2' in output, got: %s", output)
+	}
+}
+
+func TestReadyCommand_BlockedByTodo(t *testing.T) {
+	s, dir := setupReadyTestStore(t)
+
+	// Add a todo task
+	task1, err := s.Add("Blocking task", "detail 1", nil, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Add another task that depends on it
+	_, err = s.Add("Dependent task", "detail 2", []string{task1.ID}, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	cmd := readyCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	// Should contain blocking task but not dependent task
+	if !bytes.Contains(buf.Bytes(), []byte("Blocking task")) {
+		t.Errorf("expected 'Blocking task' in output, got: %s", output)
+	}
+	if bytes.Contains(buf.Bytes(), []byte("Dependent task")) {
+		t.Errorf("did not expect 'Dependent task' in output, got: %s", output)
+	}
+}
+
+func TestReadyCommand_BlockedByInProgress(t *testing.T) {
+	s, dir := setupReadyTestStore(t)
+
+	// Add an in-progress task
+	task1, err := s.Add("In-progress task", "detail 1", nil, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err = s.UpdateStatus(task1.ID, task.StatusInProgress); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	// Add another task that depends on it
+	_, err = s.Add("Dependent task", "detail 2", []string{task1.ID}, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	cmd := readyCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	// Should not contain dependent task (blocked by in-progress)
+	if bytes.Contains(buf.Bytes(), []byte("Dependent task")) {
+		t.Errorf("did not expect 'Dependent task' in output, got: %s", output)
+	}
+}
+
+func TestReadyCommand_DoneDependency(t *testing.T) {
+	s, dir := setupReadyTestStore(t)
+
+	// Add a done task
+	task1, err := s.Add("Done task", "detail 1", nil, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err = s.UpdateStatus(task1.ID, task.StatusDone); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	// Add another task that depends on it - should be ready
+	_, err = s.Add("Dependent task", "detail 2", []string{task1.ID}, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	cmd := readyCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	// Should contain dependent task (dependency is done)
+	if !bytes.Contains(buf.Bytes(), []byte("Dependent task")) {
+		t.Errorf("expected 'Dependent task' in output, got: %s", output)
+	}
+	// Should not contain done task (it's not todo)
+	if bytes.Contains(buf.Bytes(), []byte("Done task")) {
+		t.Errorf("did not expect 'Done task' in output, got: %s", output)
+	}
+}
+
+func TestReadyCommand_BlockedDependency(t *testing.T) {
+	s, dir := setupReadyTestStore(t)
+
+	// Add a blocked task
+	task1, err := s.Add("Blocked task", "detail 1", nil, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err = s.UpdateStatus(task1.ID, task.StatusBlocked); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	// Add another task that depends on it - should be ready (blocked doesn't block)
+	_, err = s.Add("Dependent task", "detail 2", []string{task1.ID}, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	cmd := readyCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	// Should contain dependent task (dependency is blocked, not todo/in-progress)
+	if !bytes.Contains(buf.Bytes(), []byte("Dependent task")) {
+		t.Errorf("expected 'Dependent task' in output, got: %s", output)
+	}
+}
+
+func TestReadyCommand_JSONOutput(t *testing.T) {
+	s, dir := setupReadyTestStore(t)
+
+	// Add a ready task
+	_, err := s.Add("Ready task", "detail 1", nil, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	// Set JSON flag
+	readyJSON = true
+	defer func() { readyJSON = false }()
+
+	// Capture stdout since printJSON writes to it
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := readyCmd
+	cmd.SetOut(w)
+	cmd.SetErr(w)
+
+	err = cmd.RunE(cmd, nil)
+
+	// Restore stdout
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatalf("failed to close pipe: %v", closeErr)
+	}
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Read the captured output
+	var outBuf bytes.Buffer
+	_, err = outBuf.ReadFrom(r)
+	if err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+
+	// Should be valid JSON
+	var tasks []task.Task
+	if err := json.Unmarshal(outBuf.Bytes(), &tasks); err != nil {
+		t.Fatalf("invalid JSON output: %v, got: %q", err, outBuf.String())
+	}
+
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 task in JSON, got %d", len(tasks))
+	}
+	if len(tasks) > 0 && tasks[0].Title != "Ready task" {
+		t.Errorf("expected 'Ready task', got %q", tasks[0].Title)
+	}
+}
+
+func TestReadyCommand_MissingDependency(t *testing.T) {
+	s, dir := setupReadyTestStore(t)
+
+	// Add a task with a non-existent dependency
+	_, err := s.Add("Task with missing dep", "detail 1", []string{"999"}, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	cmd := readyCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	// Should not contain the task (missing dep treated as blocking)
+	if bytes.Contains(buf.Bytes(), []byte("Task with missing dep")) {
+		t.Errorf("did not expect 'Task with missing dep' in output (missing dep should block), got: %s", output)
+	}
+}
+
+func TestReadyCommand_NoDependencies(t *testing.T) {
+	s, dir := setupReadyTestStore(t)
+
+	// Add tasks with various statuses but no dependencies
+	_, err := s.Add("Todo task 1", "detail 1", nil, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	task2, err2 := s.Add("Todo task 2", "detail 2", nil, nil)
+	if err2 != nil {
+		t.Fatalf("Add: %v", err2)
+	}
+	// Set to in-progress
+	if _, err2 = s.UpdateStatus(task2.ID, task.StatusInProgress); err2 != nil {
+		t.Fatalf("UpdateStatus: %v", err2)
+	}
+
+	task3, err3 := s.Add("Todo task 3", "detail 3", nil, nil)
+	if err3 != nil {
+		t.Fatalf("Add: %v", err3)
+	}
+	// Set to done
+	if _, err3 = s.UpdateStatus(task3.ID, task.StatusDone); err3 != nil {
+		t.Fatalf("UpdateStatus: %v", err3)
+	}
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	// Verify store is set up correctly
+	allTasks, err := s.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(allTasks) != 3 {
+		t.Fatalf("expected 3 tasks in store, got %d", len(allTasks))
+	}
+
+	cmd := readyCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err = cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	// Should only contain todo tasks without blocking deps
+	// Task 1 should be ready (no deps, status todo)
+	if !bytes.Contains(buf.Bytes(), []byte("Todo task 1")) {
+		t.Errorf("expected 'Todo task 1' in output, got: %s", output)
+	}
+	// Task 2 should not be ready (status in-progress)
+	if bytes.Contains(buf.Bytes(), []byte("Todo task 2")) {
+		t.Errorf("did not expect 'Todo task 2' in output (in-progress), got: %s", output)
+	}
+	// Task 3 should not be ready (status done)
+	if bytes.Contains(buf.Bytes(), []byte("Todo task 3")) {
+		t.Errorf("did not expect 'Todo task 3' in output (done), got: %s", output)
+	}
+}
+
+func TestReadyCommand_FlagReset(t *testing.T) {
+	// Ensure the flag is reset after tests
+	original := readyJSON
+	defer func() { readyJSON = original }()
+
+	// Create a temp dir for this test
+	dir, err := os.MkdirTemp("", "tssk-ready-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() {
+		if rmErr := os.RemoveAll(dir); rmErr != nil {
+			t.Logf("warning: failed to remove temp dir: %v", rmErr)
+		}
+	}()
+
+	t.Setenv("TSSK_ROOT", dir)
+
+	cmd := readyCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	// Should work without error even with flag reset
+	err = cmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(readyCmd)
 	rootCmd.AddCommand(showCmd)
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(depsCmd)


### PR DESCRIPTION
## Summary

Add a new `ready` command that lists all tasks with status 'todo' that do not depend on any task with status 'todo' or 'in-progress'. This helps users quickly identify work they can start without blocking on other tasks.

## Features

- **Filter tasks by dependency status**: Only shows tasks that are truly ready to start
- **JSON output support**: Use `--json` flag for machine-readable output
- **Warnings for missing dependencies**: Consistent with `deps check` command behavior
- **Comprehensive test coverage**: 10 test cases covering various scenarios

## Implementation Details

### New Files
- `cmd/ready.go` - Ready command implementation
- `cmd/ready_test.go` - Comprehensive test suite

### Modified Files
- `cmd/root.go` - Register ready command
- `README.md` - Document the new command

## Testing

All tests pass:
```bash
go test ./...
golangci-lint run
```

Test coverage includes:
- Empty task list
- All tasks ready (no dependencies)
- Tasks blocked by todo dependencies
- Tasks blocked by in-progress dependencies
- Tasks with done dependencies (should be ready)
- Tasks with blocked dependencies (should be ready)
- Missing dependencies (warning emitted)
- JSON output format
- Status filtering

Closes #47